### PR TITLE
Fix Nordic SVD parsing again

### DIFF
--- a/svd-rs/src/access.rs
+++ b/svd-rs/src/access.rs
@@ -48,12 +48,12 @@ impl Default for Access {
 impl Access {
     /// Parse a string into an [`Access`] value, returning [`Option::None`] if the string is not valid.
     pub fn parse_str(s: &str) -> Option<Self> {
-        match s {
+        match s.to_lowercase().as_str() {
             "read-only" => Some(Self::ReadOnly),
             "read-write" => Some(Self::ReadWrite),
-            "read-writeOnce" => Some(Self::ReadWriteOnce),
+            "read-writeonce" => Some(Self::ReadWriteOnce),
             "write-only" => Some(Self::WriteOnly),
-            "writeOnce" => Some(Self::WriteOnce),
+            "writeonce" => Some(Self::WriteOnce),
             _ => None,
         }
     }


### PR DESCRIPTION
Needed to parse the SVDs in nrf-pac, because they unfortunately don't follow the spec.

Seems this got removed at some point, see https://github.com/Dirbaio/svd/commit/8426f3bb40dd2391e26cd087a0d6510fe21fdcbc.