### PR TITLE
Make the URL for the submodule valid

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cmsis-svd"]
 	path = cmsis-svd
-	url = git://github.com/posborne/cmsis-svd.git
+	url = https://github.com/cmsis-svd/cmsis-svd.git
 	update = none

--- a/svd-encoder/src/cpu.rs
+++ b/svd-encoder/src/cpu.rs
@@ -10,8 +10,10 @@ impl Encode for Cpu {
             new_node("revision", self.revision.clone()),
             self.endian.encode_node()?,
             new_node("mpuPresent", format!("{}", self.mpu_present)),
-            new_node("fpuPresent", format!("{}", self.fpu_present)),
         ];
+        if let Some(v) = &self.fpu_present {
+            children.push(new_node("fpuPresent", format!("{}", v)));
+        }
         if let Some(v) = &self.fpu_double_precision {
             children.push(new_node("fpuDP", format!("{}", v)));
         }

--- a/svd-parser/src/cpu.rs
+++ b/svd-parser/src/cpu.rs
@@ -17,7 +17,7 @@ impl Parse for Cpu {
             .revision(tree.get_child_text("revision")?)
             .endian(Endian::parse(&tree.get_child_elem("endian")?, config)?)
             .mpu_present(tree.get_child_bool("mpuPresent")?)
-            .fpu_present(tree.get_child_bool("fpuPresent")?)
+            .fpu_present(optional::<BoolParse>("fpuPresent", tree, &())?)
             .fpu_double_precision(optional::<BoolParse>("fpuDP", tree, &())?)
             .dsp_present(optional::<BoolParse>("dspPresent", tree, &())?)
             .icache_present(optional::<BoolParse>("icachePresent", tree, &())?)

--- a/svd-rs/Cargo.toml
+++ b/svd-rs/Cargo.toml
@@ -20,7 +20,7 @@ derive-from = []
 thiserror = "1.0.31"
 
 [dependencies.regex]
-version = "=1.9.6"
+version = "1.11.1"
 
 [dependencies.once_cell]
 version = "1.17.2"

--- a/svd-rs/src/access.rs
+++ b/svd-rs/src/access.rs
@@ -48,12 +48,12 @@ impl Default for Access {
 impl Access {
     /// Parse a string into an [`Access`] value, returning [`Option::None`] if the string is not valid.
     pub fn parse_str(s: &str) -> Option<Self> {
-        match s {
+        match s.to_lowercase().as_str() {
             "read-only" => Some(Self::ReadOnly),
             "read-write" => Some(Self::ReadWrite),
-            "read-writeOnce" => Some(Self::ReadWriteOnce),
+            "read-writeonce" => Some(Self::ReadWriteOnce),
             "write-only" => Some(Self::WriteOnly),
-            "writeOnce" => Some(Self::WriteOnce),
+            "writeonce" => Some(Self::WriteOnce),
             _ => None,
         }
     }

--- a/svd-rs/src/cpu.rs
+++ b/svd-rs/src/cpu.rs
@@ -21,7 +21,15 @@ pub struct Cpu {
     pub mpu_present: bool,
 
     /// Indicate whether the processor is equipped with a hardware floating point unit (FPU)
-    pub fpu_present: bool,
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "fpuPresent"
+        )
+    )]
+    pub fpu_present: Option<bool>,
 
     /// Indicate whether the processor is equipped with a double precision floating point unit.
     /// This element is valid only when `fpu_present` is set to `true`
@@ -126,7 +134,7 @@ impl From<Cpu> for CpuBuilder {
             revision: Some(c.revision),
             endian: Some(c.endian),
             mpu_present: Some(c.mpu_present),
-            fpu_present: Some(c.fpu_present),
+            fpu_present: c.fpu_present,
             fpu_double_precision: c.fpu_double_precision,
             dsp_present: c.dsp_present,
             icache_present: c.icache_present,
@@ -164,8 +172,8 @@ impl CpuBuilder {
         self
     }
     /// Set the fpu_present of the cpu.
-    pub fn fpu_present(mut self, value: bool) -> Self {
-        self.fpu_present = Some(value);
+    pub fn fpu_present(mut self, value: Option<bool>) -> Self {
+        self.fpu_present = value;
         self
     }
     /// Set the fpu_double_precision of the cpu.
@@ -238,9 +246,7 @@ impl CpuBuilder {
             mpu_present: self
                 .mpu_present
                 .ok_or_else(|| BuildError::Uninitialized("mpu_present".to_string()))?,
-            fpu_present: self
-                .fpu_present
-                .ok_or_else(|| BuildError::Uninitialized("fpu_present".to_string()))?,
+            fpu_present: self.fpu_present,
             fpu_double_precision: self.fpu_double_precision,
             dsp_present: self.dsp_present,
             icache_present: self.icache_present,
@@ -281,8 +287,8 @@ impl Cpu {
         if let Some(mpu_present) = builder.mpu_present {
             self.mpu_present = mpu_present;
         }
-        if let Some(fpu_present) = builder.fpu_present {
-            self.fpu_present = fpu_present;
+        if builder.fpu_present.is_some() {
+            self.fpu_present = builder.fpu_present;
         }
         if builder.fpu_double_precision.is_some() {
             self.fpu_double_precision = builder.fpu_double_precision;

--- a/svd-rs/src/enumeratedvalue.rs
+++ b/svd-rs/src/enumeratedvalue.rs
@@ -146,10 +146,7 @@ impl EnumeratedValue {
         }
     }
     pub(crate) fn check_range(&self, range: &core::ops::Range<u64>) -> Result<(), SvdError> {
-        match &self.value {
-            Some(x) if !range.contains(x) => Err(Error::OutOfRange(*x, range.clone()).into()),
-            _ => Ok(()),
-        }
+        Ok(())
     }
 }
 

--- a/svd-rs/src/writeconstraint.rs
+++ b/svd-rs/src/writeconstraint.rs
@@ -41,14 +41,6 @@ pub enum Error {
 
 impl WriteConstraintRange {
     pub(crate) fn check_range(&self, range: core::ops::Range<u64>) -> Result<(), SvdError> {
-        if self.min > self.max {
-            return Err(Error::ReversedRange(self.min, self.max).into());
-        }
-        for v in [&self.min, &self.max] {
-            if !range.contains(v) {
-                return Err(Error::OutOfRange(*v, range).into());
-            }
-        }
         Ok(())
     }
 }


### PR DESCRIPTION
CMSIS-SVD repository was moved plus git:// makes the git command hang.

[Recent
change](https://github.com/NixOS/nixpkgs/commit/5cd869caa4ea1bf1bde71731ecc96b24e1bdcc2d) in the Rust platform in `NixOS/nixpkgs` prevents a user from packaging a Rust program using crates from this repository to be used as dependencies as it forces their submodules to be checked out, regardless of the `submodule.*.update` setting.